### PR TITLE
use config.yaml everywhere

### DIFF
--- a/telegrip/config.py
+++ b/telegrip/config.py
@@ -24,12 +24,12 @@ DEFAULT_CONFIG = {
     "robot": {
         "left_arm": {
             "name": "Left Arm",
-            "port": "/dev/ttySO100red",
+            "port": "/dev/ttyACM0",
             "enabled": True
         },
         "right_arm": {
             "name": "Right Arm",
-            "port": "/dev/ttySO100blue", 
+            "port": "/dev/ttyACM1",
             "enabled": True
         },
         "vr_to_robot_scale": 1.0,
@@ -132,11 +132,6 @@ IK_POSITION_ERROR_THRESHOLD = _config_data["ik"]["position_error_threshold"]
 IK_HYSTERESIS_THRESHOLD = _config_data["ik"]["hysteresis_threshold"]
 IK_MOVEMENT_PENALTY_WEIGHT = _config_data["ik"]["movement_penalty_weight"]
 
-DEFAULT_FOLLOWER_PORTS = {
-    "left": _config_data["robot"]["left_arm"]["port"],
-    "right": _config_data["robot"]["right_arm"]["port"]
-}
-
 # --- Joint Configuration ---
 JOINT_NAMES = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
 NUM_JOINTS = len(JOINT_NAMES)
@@ -175,8 +170,8 @@ GRIPPER_STEP = 10.0 # degrees
 
 # --- Device Ports ---
 DEFAULT_FOLLOWER_PORTS = {
-    "left": "/dev/ttySO100red",
-    "right": "/dev/ttySO100blue"
+    "left": _config_data["robot"]["left_arm"]["port"],
+    "right": _config_data["robot"]["right_arm"]["port"]
 }
 
 @dataclass
@@ -227,8 +222,18 @@ class TelegripConfig:
     gripper_step: float = GRIPPER_STEP
     
     def __post_init__(self):
+        # Initialize follower_ports if not set
         if self.follower_ports is None:
-            self.follower_ports = DEFAULT_FOLLOWER_PORTS.copy()
+            self.follower_ports = {
+                "left": _config_data["robot"]["left_arm"]["port"],
+                "right": _config_data["robot"]["right_arm"]["port"]
+            }
+        
+        # Ensure ports are not None
+        if self.follower_ports["left"] is None:
+            self.follower_ports["left"] = "/dev/ttyACM0"
+        if self.follower_ports["right"] is None:
+            self.follower_ports["right"] = "/dev/ttyACM1"
     
     @property
     def ssl_files_exist(self) -> bool:

--- a/telegrip/main.py
+++ b/telegrip/main.py
@@ -732,14 +732,17 @@ def parse_arguments():
     parser.add_argument("--key", default="key.pem", help="Path to SSL private key")
     
     # Robot settings
-    parser.add_argument("--left-port", default="/dev/ttySO100red", help="Left arm serial port")
-    parser.add_argument("--right-port", default="/dev/ttySO100blue", help="Right arm serial port")
+    parser.add_argument("--config", default="config.yaml", help="Path to config file")
+    parser.add_argument("--left-port", help="Left arm serial port (overrides config file)")
+    parser.add_argument("--right-port", help="Right arm serial port (overrides config file)")
     
     return parser.parse_args()
 
 
 def create_config_from_args(args) -> TelegripConfig:
     """Create configuration object from command line arguments."""
+    # First load the config file
+    config_data = get_config_data()
     config = TelegripConfig()
     
     # Apply command line overrides
@@ -758,10 +761,12 @@ def create_config_from_args(args) -> TelegripConfig:
     config.certfile = args.cert
     config.keyfile = args.key
     
-    config.follower_ports = {
-        "left": args.left_port,
-        "right": args.right_port
-    }
+    # Handle port configuration - use command line args if provided, otherwise use config file values
+    if args.left_port or args.right_port:
+        config.follower_ports = {
+            "left": args.left_port if args.left_port else config_data["robot"]["left_arm"]["port"],
+            "right": args.right_port if args.right_port else config_data["robot"]["right_arm"]["port"]
+        }
     
     return config
 

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -34,7 +34,7 @@
               </div>
               <div class="form-group">
                 <label for="leftArmPort">Left Arm Port</label>
-                <input type="text" id="leftArmPort" name="leftArmPort" placeholder="/dev/ttySO100red">
+                <input type="text" id="leftArmPort" name="leftArmPort" placeholder="/dev/ttyACM0">
               </div>
             </div>
             <div class="form-row">
@@ -44,7 +44,7 @@
               </div>
               <div class="form-group">
                 <label for="rightArmPort">Right Arm Port</label>
-                <input type="text" id="rightArmPort" name="rightArmPort" placeholder="/dev/ttySO100blue">
+                <input type="text" id="rightArmPort" name="rightArmPort" placeholder="/dev/ttyACM1">
               </div>
             </div>
           </div>


### PR DESCRIPTION
The addresses for the arms was not read from the `config.yaml` everywhere as reported in https://github.com/DipFlip/telegrip/issues/1
This MR should fix that 