### PR TITLE
Fix headless mode and add --no-sim flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ telegrip [OPTIONS]
 
 Options:
   --no-robot        Disable robot connection (visualization only)
-  --no-viz          Disable PyBullet visualization  
+  --no-sim          Disable PyBullet simulation and inverse kinematics
+  --no-viz          Disable PyBullet visualization (headless mode)
   --no-vr           Disable VR WebSocket server
   --no-keyboard     Disable keyboard input
   --log-level LEVEL Set logging level: debug, info, warning, error, critical (default: warning)
@@ -109,6 +110,11 @@ telegrip --no-robot
 **Keyboard Only** (no VR):
 ```bash
 telegrip --no-vr
+```
+
+**No Simulation** (no PyBullet sim or IK):
+```bash
+telegrip --no-sim
 ```
 
 **Headless** (no PyBullet GUI):

--- a/telegrip/config.py
+++ b/telegrip/config.py
@@ -201,6 +201,7 @@ class TelegripConfig:
     
     # Control flags
     enable_pybullet: bool = True
+    enable_pybullet_gui: bool = True
     enable_robot: bool = True
     enable_vr: bool = True
     enable_keyboard: bool = True

--- a/telegrip/control_loop.py
+++ b/telegrip/control_loop.py
@@ -90,7 +90,7 @@ class ControlLoop:
             if self.config.enable_robot:
                 success = False
         
-        # Setup PyBullet visualizer
+        # Setup PyBullet simulation, IK and visualizer
         if self.config.enable_pybullet:
             try:
                 # Import PyBulletVisualizer on demand
@@ -98,7 +98,7 @@ class ControlLoop:
                 
                 self.visualizer = PyBulletVisualizer(
                     self.config.urdf_path, 
-                    use_gui=True,
+                    use_gui=self.config.enable_pybullet_gui,
                     log_level=self.config.log_level
                 )
                 if not self.visualizer.setup():

--- a/telegrip/main.py
+++ b/telegrip/main.py
@@ -712,7 +712,8 @@ def parse_arguments():
     
     # Control flags
     parser.add_argument("--no-robot", action="store_true", help="Disable robot connection (visualization only)")
-    parser.add_argument("--no-viz", action="store_true", help="Disable PyBullet visualization")
+    parser.add_argument("--no-sim", action="store_true", help="Disable PyBullet simulation and inverse kinematics")
+    parser.add_argument("--no-viz", action="store_true", help="Disable PyBullet visualization (headless mode)")
     parser.add_argument("--no-vr", action="store_true", help="Disable VR WebSocket server")
     parser.add_argument("--no-keyboard", action="store_true", help="Disable keyboard input")
     parser.add_argument("--no-https", action="store_true", help="Disable HTTPS server")
@@ -744,7 +745,8 @@ def create_config_from_args(args) -> TelegripConfig:
     
     # Apply command line overrides
     config.enable_robot = not args.no_robot
-    config.enable_pybullet = not args.no_viz
+    config.enable_pybullet = not args.no_sim
+    config.enable_pybullet_gui = config.enable_pybullet and not args.no_viz
     config.enable_vr = not args.no_vr
     config.enable_keyboard = not args.no_keyboard
     config.log_level = args.log_level
@@ -803,6 +805,7 @@ async def main():
         logger.info("Starting with configuration:")
         logger.info(f"  Robot: {'enabled' if config.enable_robot else 'disabled'}")
         logger.info(f"  PyBullet: {'enabled' if config.enable_pybullet else 'disabled'}")
+        logger.info(f"  Headless mode: {'enabled' if not config.enable_pybullet_gui and config.enable_pybullet else 'disabled'}")
         logger.info(f"  VR: {'enabled' if config.enable_vr else 'disabled'}")
         logger.info(f"  Keyboard: {'enabled' if config.enable_keyboard else 'disabled'}")
         logger.info(f"  HTTPS Port: {config.https_port}")


### PR DESCRIPTION
## Problem
Simulation and IK wouldn't initialize when running headless with `--no-viz` flag.

## Fix
1. Created a `--no-sim` flag to disable PyBullet entirely (like the `--no-viz` flag used to) and changed the `--no-viz` flag to disable the PyBullet GUI.  This keeps the simulation and IK functionality in tact.

2. Updated README and logging to match this new flag.