### PR TITLE
remove unused async in control_loop setup

### DIFF
--- a/telegrip/control_loop.py
+++ b/telegrip/control_loop.py
@@ -69,7 +69,7 @@ class ControlLoop:
         
         self.is_running = False
     
-    async def setup(self) -> bool:
+    def setup(self) -> bool:
         """Setup robot interface and visualizer."""
         success = True
         setup_errors = []
@@ -138,7 +138,7 @@ class ControlLoop:
     
     async def start(self):
         """Start the control loop."""
-        if not await self.setup():
+        if not self.setup():
             logger.error("Control loop setup failed")
             return
         


### PR DESCRIPTION
Hi, 

I am going through this amazing work. I noticed that `self.setup` in `ControlLoop` does not have any `async` parts, and can be removed gracefully. 